### PR TITLE
5 handle different forms of words

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,10 @@
       "name": "corpus-word-freq",
       "version": "0.1.0",
       "license": "MIT",
+      "dependencies": {
+        "wink-eng-lite-web-model": "^1.5.0",
+        "wink-nlp": "^1.13.1"
+      },
       "devDependencies": {
         "he": "^1.2.0",
         "husky": "^8.0.3",
@@ -12136,6 +12140,22 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/wink-eng-lite-web-model": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/wink-eng-lite-web-model/-/wink-eng-lite-web-model-1.5.0.tgz",
+      "integrity": "sha512-5t27uqKRpQVyjb+ztIabmD2m76ct+5NP9e3TVxla4GBQzgPJnAHCynPw4KQa42BNn5xxi7b7E9P3akSFiYWHbg==",
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "wink-nlp": ">1.8.1"
+      }
+    },
+    "node_modules/wink-nlp": {
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/wink-nlp/-/wink-nlp-1.13.1.tgz",
+      "integrity": "sha512-JhZpPhGxUhGhqSykManCHkRRUU07LgqiAnG14HT7ZS4p3rKnanKJwl1NSwenEmUIwr4aEik3BWLoEF49xkrsyQ=="
     },
     "node_modules/word-wrap": {
       "version": "1.2.3",

--- a/package.json
+++ b/package.json
@@ -38,5 +38,9 @@
     "tsdx": "^0.14.1",
     "tslib": "^2.5.0",
     "typescript": "^4.9.5"
+  },
+  "dependencies": {
+    "wink-eng-lite-web-model": "^1.5.0",
+    "wink-nlp": "^1.13.1"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,7 +37,7 @@ export type WordObject = {
 };
 
 const corpusObject = (posToRemove: patternOfSpeech[] | null = null) => {
-  const nlp = winkNLP(model);
+  const nlp = winkNLP(model, ['sbd', 'pos']);
 
   const compressedWordFreqList = readFileSync(
     `${__dirname}/wordFreqList.json.gz`

--- a/src/index.ts
+++ b/src/index.ts
@@ -51,7 +51,11 @@ const corpusObject = (posToRemove: patternOfSpeech[] | null = null) => {
   );
 
   const getWordFrequency = (word: string) => {
-    const wordObject = wordFreqList.find(e => e.word === word);
+    const doc = nlp.readDoc(word);
+    // const lemmatisedWord = doc.tokens().out(nlp.its.lemma)[0];
+    const lemmatisedWord = doc.out(nlp.its.lemma);
+
+    const wordObject = wordFreqList.find(e => e.word === lemmatisedWord);
 
     if (wordObject === undefined) return null;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,9 @@ import { readFileSync } from 'fs';
 
 import { unzipSync } from 'zlib';
 
+import winkNLP from 'wink-nlp';
+import model from 'wink-eng-lite-web-model';
+
 export type patternOfSpeech =
   | 'Uncl'
   | 'DetP'
@@ -34,6 +37,8 @@ export type WordObject = {
 };
 
 const corpusObject = (posToRemove: patternOfSpeech[] | null = null) => {
+  const nlp = winkNLP(model);
+
   const compressedWordFreqList = readFileSync(
     `${__dirname}/wordFreqList.json.gz`
   );
@@ -66,6 +71,9 @@ const corpusObject = (posToRemove: patternOfSpeech[] | null = null) => {
     const lowerCasedWordList = wordList.map(e => e.toLowerCase());
     const matchedWords: WordObject[] = [];
 
+    const doc = nlp.readDoc(lowerCasedWordList.join(' '));
+    const lemmatisedWordList = doc.tokens().out(nlp.its.lemma);
+
     for (const wordObject of freqList) {
       if (matchedWords.length === desiredMatches) break;
       const isWordDuplicate = matchedWords.some(
@@ -74,7 +82,7 @@ const corpusObject = (posToRemove: patternOfSpeech[] | null = null) => {
 
       if (isWordDuplicate) continue;
 
-      const matchedWordObject = lowerCasedWordList.find(
+      const matchedWordObject = lemmatisedWordList.find(
         word => word === wordObject.word
       );
       if (matchedWordObject) matchedWords.push(wordObject);


### PR DESCRIPTION
Use WinkNLP to lemmatise passed words and compare based on those.

Slight caveat with this is that what we return may not technically be truthful when compared to what they passed in - for example, they pass in the term frequencies, we lemmatise that to frequency, then return the match found on frequency rather than the word frequencies.

In the future we could counter this by being able to pass in an option regarding whether we return the base word or the lemmatised word.